### PR TITLE
Fix `NE_RichTextMetadataLoadFAT` returning error code `0` on success

### DIFF
--- a/source/NERichText.c
+++ b/source/NERichText.c
@@ -112,7 +112,7 @@ int NE_RichTextMetadataLoadFAT(u32 slot, const char *path)
 
     info->handle = handle;
 
-    return 0;
+    return 1;
 }
 
 int NE_RichTextMetadataLoadMemory(u32 slot, const void *data, size_t data_size)


### PR DESCRIPTION
Fixes this method just seeming to be returning the wrong integer error :)