### PR TITLE
rich text: Allow the number of fonts to be specified dynamically

### DIFF
--- a/examples/text/font_from_nitrofs/source/main.c
+++ b/examples/text/font_from_nitrofs/source/main.c
@@ -20,9 +20,9 @@ void Draw3DScene1(void *arg)
 
     NE_2DViewInit();
 
-    NE_RichTextRender3D(3, "VAWATa\ntajl", 0, 0);
+    NE_RichTextRender3D(1, "VAWATa\ntajl", 0, 0);
 
-    NE_RichTextRender3DAlpha(2, "Text with alpha", 10, 80,
+    NE_RichTextRender3DAlpha(0, "Text with alpha", 10, 80,
                              POLY_ALPHA(20) | POLY_CULL_BACK, 30);
 }
 
@@ -70,28 +70,28 @@ int main(int argc, char *argv[])
 
     // Load a 16-color font to be used for rendering text as quads
 
-    NE_RichTextInit(2);
-    NE_RichTextMetadataLoadFAT(2, "fonts/font.fnt");
-    NE_RichTextMaterialLoadGRF(2, "fonts/font_16_png.grf");
+    NE_RichTextInit(0);
+    NE_RichTextMetadataLoadFAT(0, "fonts/font.fnt");
+    NE_RichTextMaterialLoadGRF(0, "fonts/font_16_png.grf");
 
     // Load a 256-color font to be used for rendering text as quads
 
-    NE_RichTextInit(3);
-    NE_RichTextMetadataLoadFAT(3, "fonts/font.fnt");
-    NE_RichTextMaterialLoadGRF(3, "fonts/font_256_png.grf");
+    NE_RichTextInit(1);
+    NE_RichTextMetadataLoadFAT(1, "fonts/font.fnt");
+    NE_RichTextMaterialLoadGRF(1, "fonts/font_256_png.grf");
 
     // Load a 16-color font to be used for rendering text to textures.
 
-    NE_RichTextInit(5);
-    NE_RichTextMetadataLoadFAT(5, "fonts/font.fnt");
-    NE_RichTextBitmapLoadGRF(5, "fonts/font_16_png.grf");
+    NE_RichTextInit(2);
+    NE_RichTextMetadataLoadFAT(2, "fonts/font.fnt");
+    NE_RichTextBitmapLoadGRF(2, "fonts/font_16_png.grf");
 
     // Render text to a texture using the last font we've loaded
 
     // We don't care about managing the palette. Passing NULL will tell Nitro
     // Engine to delete the palete automatically when the material is deleted.
     NE_Material *Material = NULL;
-    NE_RichTextRenderMaterial(5,
+    NE_RichTextRenderMaterial(2,
                 "Sample: AWAV.\nÿ_ßðñÑü(o´Áá)|\nInvalid char: ŋ",
                 &Material, NULL);
 
@@ -114,9 +114,7 @@ int main(int argc, char *argv[])
     NE_SpriteDelete(Scene.TextSprite);
     NE_MaterialDelete(Material);
 
-    NE_RichTextEnd(2);
-    NE_RichTextEnd(3);
-    NE_RichTextEnd(5);
+    NE_RichTextResetSystem();
 
     return 0;
 }

--- a/examples/text/font_from_ram/source/main.c
+++ b/examples/text/font_from_ram/source/main.c
@@ -23,9 +23,9 @@ void Draw3DScene(void *arg)
 
     NE_2DViewInit();
 
-    NE_RichTextRender3D(3, "VAWATa\ntajl", 0, 0);
+    NE_RichTextRender3D(1, "VAWATa\ntajl", 0, 0);
 
-    NE_RichTextRender3DAlpha(2, "Text with alpha", 10, 80,
+    NE_RichTextRender3DAlpha(0, "Text with alpha", 10, 80,
                              POLY_ALPHA(20) | POLY_CULL_BACK, 30);
 }
 
@@ -55,8 +55,8 @@ int main(int argc, char *argv[])
 
     // Load a 16-color font to be used for rendering text as quads
 
-    NE_RichTextInit(2);
-    NE_RichTextMetadataLoadMemory(2, font_fnt_bin, font_fnt_bin_size);
+    NE_RichTextInit(0);
+    NE_RichTextMetadataLoadMemory(0, font_fnt_bin, font_fnt_bin_size);
 
     {
         NE_Material *Font16 = NE_MaterialCreate();
@@ -71,13 +71,13 @@ int main(int argc, char *argv[])
 
         // The material and palette will be deleted when the rich text font is
         // deleted.
-        NE_RichTextMaterialSet(2, Font16, Pal16);
+        NE_RichTextMaterialSet(0, Font16, Pal16);
     }
 
     // Load a 256-color font to be used for rendering text as quads
 
-    NE_RichTextInit(3);
-    NE_RichTextMetadataLoadMemory(3, font_fnt_bin, font_fnt_bin_size);
+    NE_RichTextInit(1);
+    NE_RichTextMetadataLoadMemory(1, font_fnt_bin, font_fnt_bin_size);
 
     {
         NE_Material *Font256 = NE_MaterialCreate();
@@ -92,14 +92,14 @@ int main(int argc, char *argv[])
 
         // The material and palette will be deleted when the rich text font is
         // deleted.
-        NE_RichTextMaterialSet(3, Font256, Pal256);
+        NE_RichTextMaterialSet(1, Font256, Pal256);
     }
 
     // Load a 16-color font to be used for rendering text to textures.
 
-    NE_RichTextInit(5);
-    NE_RichTextMetadataLoadMemory(5, font_fnt_bin, font_fnt_bin_size);
-    NE_RichTextBitmapSet(5, font_16Bitmap, 256, 256, NE_PAL16,
+    NE_RichTextInit(2);
+    NE_RichTextMetadataLoadMemory(2, font_fnt_bin, font_fnt_bin_size);
+    NE_RichTextBitmapSet(2, font_16Bitmap, 256, 256, NE_PAL16,
                          font_16Pal, font_16PalLen);
 
     // Render text to a texture using the last font we've loaded
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
     // We don't care about managing the palette. Passing NULL will tell Nitro
     // Engine to delete the palete automatically when the material is deleted.
     NE_Material *Material = NULL;
-    NE_RichTextRenderMaterial(5,
+    NE_RichTextRenderMaterial(2,
                 "Sample: AWAV.\nÿ_ßðñÑü(o´Áá)|\nInvalid char: ŋ",
                 &Material, NULL);
 
@@ -130,9 +130,7 @@ int main(int argc, char *argv[])
     NE_SpriteDelete(Scene.TextSprite);
     NE_MaterialDelete(Material);
 
-    NE_RichTextEnd(2);
-    NE_RichTextEnd(3);
-    NE_RichTextEnd(5);
+    NE_RichTextResetSystem();
 
     return 0;
 }

--- a/include/NERichText.h
+++ b/include/NERichText.h
@@ -34,7 +34,8 @@
 ///
 /// @{
 
-#define NE_MAX_RICH_TEXT_FONTS 8 ///< Default max number of rich text fonts
+#define NE_DEFAULT_RICH_TEXT_FONTS 8 ///< Default max number of rich text fonts
+#define NE_MAX_RICH_TEXT_FONTS NE_DEFAULT_RICH_TEXT_FONTS ///< Deprecated and unused, left for compatibility
 
 /// Change the priority of rich text drawn after this function call.
 ///
@@ -44,12 +45,20 @@ void NE_RichTextPrioritySet(int priority);
 /// Set to 0 the priority of rich text drawn after this function call.
 void NE_RichTextPriorityReset(void);
 
+/// Initializes the rich text system with the specified number of slots.
+///
+/// This must be called before initializing any rich text slots.
+///
+/// @param numSlots The number of rich text slots to allocate.
+/// @return Returns 1 on success, 0 on failure.
+int NE_RichTextStartSystem(u32 numSlots);
+
 /// Clears all rich text font slots.
 void NE_RichTextResetSystem(void);
 
 /// Initialize a rich text slot.
 ///
-/// @param slot The slot to initialize (from 0 to NE_MAX_RICH_TEXT_FONTS).
+/// @param slot The slot to initialize (from 0 to the number of slots specified in NE_RichTextSystemStart).
 void NE_RichTextInit(u32 slot);
 
 /// End a rich text slot and free all the resources used by it.


### PR DESCRIPTION
This switches the rich text library from using a constant for the max number of fonts to allowing the user to specify how many fonts should be used dynamically. To accomplish this, a new method is introduced to the rich text system: `NE_RichTextStartSystem`, which accepts the number of slots to allocate. Those slots are allocated and then freed when `NE_RichTextResetSystem` is called.

To maintain compatibility, I have not removed `NE_MAX_RICH_TEXT_FONTS` (instead opting to mark it as deprecated), and have added functionality to automatically call `NE_RichTextStartSystem` with that old value (8) if the user decides to init a rich text slot before calling `NE_RichTextStartSystem` (which would likely be the previous default behavior).