### PR TITLE
rich text: Ensure final position is returned on dry run with cursor

### DIFF
--- a/source/libdsf/dsf.c
+++ b/source/libdsf/dsf.c
@@ -587,6 +587,8 @@ dsf_error DSF_StringRenderDryRunWithCursor(dsf_handle handle, const char *str,
 
     *size_x = max_x;
     *size_y = max_y + font->line_height;
+    *final_x = font->pointer_x;
+    *final_y = font->pointer_y;
 
     return ret;
 }


### PR DESCRIPTION
Commit 8932de1 had a minor bug in it that I only just now noticed -- the cursor positions in `DSF_StringRenderDryRunWithCursor` are only returned when string length is 0. This is definitely just a rebase error -- my apologies for not getting around to rebasing it properly sooner!