### PR TITLE
Add x and y axis independent sprite scaling

### DIFF
--- a/include/NE2D.h
+++ b/include/NE2D.h
@@ -30,7 +30,8 @@ typedef struct {
     s16 w;            ///< Width in pixels
     s16 h;            ///< Height in pixels
     int rot_angle;    ///< Rotation
-    int scale;        ///< Scale (f32)
+    int xscale;       ///< Scale X (f32)
+    int yscale;       ///< Scale Y (f32)
     int priority;     ///< Priority (Z coordinate)
     u32 color;        ///< Color
     NE_Material *mat; ///< Material
@@ -86,6 +87,32 @@ void NE_SpriteSetScaleI(NE_Sprite *sprite, int scale);
 /// @param scale Scale factor (float).
 #define NE_SpriteSetScale(sprite, scale) \
     NE_SpriteSetScaleI(sprite, floattof32(scale))
+
+/// Scales a sprite from its center.
+///
+/// @param sprite Sprite to be scaled.
+/// @param scale Scale factor (f32).
+void NE_SpriteSetXScaleI(NE_Sprite *sprite, int scale);
+
+/// Scales a sprite from its center.
+///
+/// @param sprite Sprite to be scaled.
+/// @param scale Scale factor (float).
+#define NE_SpriteSetXScale(sprite, scale) \
+    NE_SpriteSetXScaleI(sprite, floattof32(scale))
+
+/// Scales a sprite from its center.
+///
+/// @param sprite Sprite to be scaled.
+/// @param scale Scale factor (f32).
+void NE_SpriteSetYScaleI(NE_Sprite *sprite, int scale);
+
+/// Scales a sprite from its center.
+///
+/// @param sprite Sprite to be scaled.
+/// @param scale Scale factor (float).
+#define NE_SpriteSetYScale(sprite, scale) \
+    NE_SpriteSetYScaleI(sprite, floattof32(scale))
 
 /// Assign a material to a sprite.
 ///
@@ -201,24 +228,27 @@ void NE_2DViewRotateByPosition(int x, int y, int rotz);
 //
 /// @param x (x, y) Coordinates.
 /// @param y (x, y) Coordinates.
-/// @param scale Scale factor (f32).
-void NE_2DViewScaleByPositionI(int x, int y, int scale);
+/// @param xscale x axis scale factor (f32).
+/// @param yscale y axis scale factor (f32).
+void NE_2DViewScaleByPositionI(int x, int y, int xscale, int yscale);
 
 /// Scales the current 2D view from the specified point.
 //
 /// @param x (x, y) Coordinates.
 /// @param y (x, y) Coordinates.
-/// @param s Scale factor (float).
-#define NE_2DViewScaleByPosition(x, y, s) \
-    NE_2DViewScaleByPositionI(x, y, floattof32(s))
+/// @param sx x axis scale factor (float).
+/// @param sy y axis scale factor (float).
+#define NE_2DViewScaleByPosition(x, y, sx, sy) \
+    NE_2DViewScaleByPositionI(x, y, floattof32(sx), floattof32(sy))
 
 /// Rotates and scales the current 2D view from the specified point.
 ///
 /// @param x (x, y) Coordinates.
 /// @param y (x, y) Coordinates.
 /// @param rotz Angle (0-512) to rotate on the Z axis.
-/// @param scale Scale factor (f32).
-void NE_2DViewRotateScaleByPositionI(int x, int y, int rotz, int scale);
+/// @param xscale x axis scale factor (f32).
+/// @param yscale y axis scale factor (f32).
+void NE_2DViewRotateScaleByPositionI(int x, int y, int rotz, int xscale, int yscale);
 
 /// Rotates and scales the current 2D view from the specified point.
 //

--- a/source/NE2D.c
+++ b/source/NE2D.c
@@ -35,7 +35,8 @@ NE_Sprite *NE_SpriteCreate(void)
         }
 
         sprite->visible = true;
-        sprite->scale = inttof32(1);
+        sprite->xscale = inttof32(1);
+        sprite->yscale = inttof32(1);
         sprite->color = NE_White;
         sprite->mat = NULL;
         sprite->alpha = 31;
@@ -72,7 +73,20 @@ void NE_SpriteSetRot(NE_Sprite *sprite, int angle)
 void NE_SpriteSetScaleI(NE_Sprite *sprite, int scale)
 {
     NE_AssertPointer(sprite, "NULL pointer");
-    sprite->scale = scale;
+    sprite->xscale = scale;
+    sprite->yscale = scale;
+}
+
+void NE_SpriteSetXScaleI(NE_Sprite *sprite, int scale)
+{
+    NE_AssertPointer(sprite, "NULL pointer");
+    sprite->xscale = scale;
+}
+
+void NE_SpriteSetYScaleI(NE_Sprite *sprite, int scale)
+{
+    NE_AssertPointer(sprite, "NULL pointer");
+    sprite->yscale = scale;
 }
 
 void NE_SpriteSetMaterial(NE_Sprite *sprite, NE_Material *mat)
@@ -208,13 +222,13 @@ void NE_SpriteDraw(const NE_Sprite *sprite)
         NE_2DViewRotateScaleByPositionI(sprite->x + (sprite->w >> 1),
                                         sprite->y + (sprite->h >> 1),
                                         sprite->rot_angle,
-                                        sprite->scale);
+                                        sprite->xscale, sprite->yscale);
     }
     else
     {
         NE_2DViewScaleByPositionI(sprite->x + (sprite->w >> 1),
                                   sprite->y + (sprite->h >> 1),
-                                  sprite->scale);
+                                  sprite->xscale, sprite->yscale);
     }
 
     GFX_POLY_FORMAT = POLY_ALPHA(sprite->alpha) | POLY_ID(sprite->id) |
@@ -254,13 +268,13 @@ void NE_SpriteDrawAll(void)
             NE_2DViewRotateScaleByPositionI(sprite->x + (sprite->w >> 1),
                                             sprite->y + (sprite->h >> 1),
                                             sprite->rot_angle,
-                                            sprite->scale);
+                                            sprite->xscale, sprite->yscale);
         }
         else
         {
             NE_2DViewScaleByPositionI(sprite->x + (sprite->w >> 1),
                                       sprite->y + (sprite->h >> 1),
-                                      sprite->scale);
+                                      sprite->xscale, sprite->yscale);
         }
 
         GFX_POLY_FORMAT = POLY_ALPHA(sprite->alpha) |
@@ -340,12 +354,12 @@ void NE_2DViewInit(void)
     NE_PolyFormat(31, 0, 0, NE_CULL_NONE, 0);
 }
 
-void NE_2DViewRotateScaleByPositionI(int x, int y, int rotz, int scale)
+void NE_2DViewRotateScaleByPositionI(int x, int y, int rotz, int xscale, int yscale)
 {
     NE_ViewMoveI(x, y, 0);
 
-    MATRIX_SCALE = scale;
-    MATRIX_SCALE = scale;
+    MATRIX_SCALE = xscale;
+    MATRIX_SCALE = yscale;
     MATRIX_SCALE = inttof32(1);
 
     glRotateZi(rotz << 6);
@@ -362,12 +376,12 @@ void NE_2DViewRotateByPosition(int x, int y, int rotz)
     NE_ViewMoveI(-x, -y, 0);
 }
 
-void NE_2DViewScaleByPositionI(int x, int y, int scale)
+void NE_2DViewScaleByPositionI(int x, int y, int xscale, int yscale)
 {
     NE_ViewMoveI(x, y, 0);
 
-    MATRIX_SCALE = scale;
-    MATRIX_SCALE = scale;
+    MATRIX_SCALE = xscale;
+    MATRIX_SCALE = yscale;
     MATRIX_SCALE = inttof32(1);
 
     NE_ViewMoveI(-x, -y, 0);


### PR DESCRIPTION
I added this feature for a game I'm personally working on and am opening this if it is a desired upstream feature.

Feature allows for X and Y axis sprite scaling, presently sprite scaling affects both axis. This additionally will allow for horizontal and vertical flip of sprites by nature of independent axis scaling.