### PR TITLE
rich text: fix off-by-one error with rendering to materials, change assumptions about rendering translucent textures to materials, trim heights of rendered textures to save VRAM

### DIFF
--- a/source/libdsf/dsf.c
+++ b/source/libdsf/dsf.c
@@ -750,12 +750,12 @@ static dsf_error DSF_CodepointRenderBuffer(dsf_handle handle,
         src += tx1 + ty1 * font_width;
         dst += x1 + y1 * out_width;
 
-        for (int y = 0; y <= y2 - y1; y++)
+        for (int y = 0; y < y2 - y1; y++)
         {
             const uint8_t *src_row = src;
             uint8_t *dst_row = dst;
 
-            for (int x = 0; x <= x2 - x1; x++)
+            for (int x = 0; x < x2 - x1; x++)
             {
                 uint8_t color = *src_row++;
                 if (color != 0)
@@ -775,12 +775,12 @@ static dsf_error DSF_CodepointRenderBuffer(dsf_handle handle,
         src += tx1 + ty1 * font_width;
         dst += x1 + y1 * out_width;
 
-        for (int y = 0; y <= y2 - y1; y++)
+        for (int y = 0; y < y2 - y1; y++)
         {
             const uint16_t *src_row = src;
             uint16_t *dst_row = dst;
 
-            for (int x = 0; x <= x2 - x1; x++)
+            for (int x = 0; x < x2 - x1; x++)
             {
                 uint16_t color = *src_row++;
                 if (color & BIT(15))
@@ -800,29 +800,18 @@ static dsf_error DSF_CodepointRenderBuffer(dsf_handle handle,
         src += tx1 + ty1 * font_width;
         dst += x1 + y1 * out_width;
 
-        int alpha_shift;
-
-        if (texture_fmt == GL_RGB32_A3)
-            alpha_shift = 5;
-        else // if (texture_fmt == GL_RGB8_A5)
-            alpha_shift = 3;
-
-        for (int y = 0; y <= y2 - y1; y++)
+        for (int y = 0; y < y2 - y1; y++)
         {
             const uint8_t *src_row = src;
             uint8_t *dst_row = dst;
 
-            for (int x = 0; x <= x2 - x1; x++)
+            for (int x = 0; x < x2 - x1; x++)
             {
-                uint8_t color = *src_row++;
                 // We can't really blend two different colors because we're
-                // limited by the palette. For that reason, if the new alpha is
-                // 0 we leave the old entry. If the new alpha is anything other
-                // than 0, we replace the old entry by the new entry, even if
-                // the result is incorrect.
-                if ((color >> alpha_shift) != 0)
-                    *dst_row = color;
-                dst_row++;
+                // limited by the palette. For that reason, we just directly
+                // copy to the new texture under the assumption that the user
+                // will be using a transparent texture as a base.
+                *dst_row++ = *src_row++;
             }
 
             src += font_width;
@@ -834,12 +823,12 @@ static dsf_error DSF_CodepointRenderBuffer(dsf_handle handle,
         const uint8_t *src = font_texture;
         uint8_t *dst = out_texture;
 
-        for (int y = 0; y <= y2 - y1; y++)
+        for (int y = 0; y < y2 - y1; y++)
         {
             const uint8_t *src_row = src + (((ty1 + y) * font_width) >> 1);
             uint8_t *dst_row = dst + (((y1 + y) * out_width) >> 1);
 
-            for (int x = 0; x <= x2 - x1; x++)
+            for (int x = 0; x < x2 - x1; x++)
             {
                 const uint8_t *src_px = src_row + ((tx1 + x) >> 1);
                 uint8_t *dst_px = dst_row + ((x1 + x) >> 1);
@@ -861,12 +850,12 @@ static dsf_error DSF_CodepointRenderBuffer(dsf_handle handle,
         const uint8_t *src = font_texture;
         uint8_t *dst = out_texture;
 
-        for (int y = 0; y <= y2 - y1; y++)
+        for (int y = 0; y < y2 - y1; y++)
         {
             const uint8_t *src_row = src + (((ty1 + y) * font_width) >> 2);
             uint8_t *dst_row = dst + (((y1 + y) * out_width) >> 2);
 
-            for (int x = 0; x <= x2 - x1; x++)
+            for (int x = 0; x < x2 - x1; x++)
             {
                 const uint8_t *src_px = src_row + ((tx1 + x) >> 2);
                 uint8_t *dst_px = dst_row + ((x1 + x) >> 2);
@@ -923,21 +912,13 @@ dsf_error DSF_StringRenderToTexture(dsf_handle handle,
         return DSF_TEXTURE_TOO_BIG;
 
     // Expand to a valid texture size
+    // We only expand the width as leaving the height clipped saves VRAM
 
     for (size_t i = 8; i <= 1024; i <<= 1)
     {
         if (tex_width <= i)
         {
             tex_width = i;
-            break;
-        }
-    }
-
-    for (size_t i = 8; i <= 1024; i <<= 1)
-    {
-        if (tex_height <= i)
-        {
-            tex_height = i;
             break;
         }
     }


### PR DESCRIPTION
Three fixes in one:
* There was an off-by-one error that was causing junk to be copied into rendered materials; this fixes that
* Previously, it was assumed that the inability to handle blending on the software-level necessitated flattening translucence on A5PAL8 and A3PAL32 textures. This assumption has been replaced with the assumption that the user will render the font to a transparent texture of the same format, thus necessitating a direct copy instead. I think this is probably truer to the actual intended usage here.
* Previously, texture buffers were being expanded to match the full height of a valid DS texture height; however, this is not necessary and I would argue that it is better to trim the buffer to the actual height of the texture as that will save VRAM.

The first fix was discussed, but I had already made the other changes while I was doing my investigation, so I thought I'd include them as well. If you'd like me to remove any of them or make any changes, please just let me know!